### PR TITLE
Revamp navigation

### DIFF
--- a/app.json
+++ b/app.json
@@ -20,7 +20,7 @@
       },
       "supportsTablet": true,
       "bundleIdentifier": "com.jamesalmeida.memex",
-      "buildNumber": "2025.12.03.1",
+      "buildNumber": "2025.12.03.2",
       "infoPlist": {
         "NSLocalNetworkUsageDescription": "This app needs local network access to connect to the Metro development server.",
         "ITSAppUsesNonExemptEncryption": false,

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -18,6 +18,7 @@ import CreateSpaceSheet from '../../src/components/CreateSpaceSheet';
 import EditSpaceSheet, { EditSpaceSheetRef } from '../../src/components/EditSpaceSheet';
 import ReorderSpacesSheet, { ReorderSpacesSheetRef } from '../../src/components/ReorderSpacesSheet';
 import ChatSheet from '../../src/components/ChatSheet';
+import AttachmentSheet from '../../src/components/AttachmentSheet';
 import HomeScreen from './index';
 import SpacesScreen from './spacesGrid';
 import AssistantScreen from './assistant';
@@ -27,7 +28,9 @@ import ExpandedItemView from '../../src/components/ExpandedItemView';
 import { expandedItemUIStore, expandedItemUIActions } from '../../src/stores/expandedItemUI';
 import { useDrawer } from '../../src/contexts/DrawerContext';
 import { spacesComputed } from '../../src/stores/spaces';
+import { filterActions } from '../../src/stores/filter';
 import { useToast } from '../../src/contexts/ToastContext';
+import { SPECIAL_SPACES } from '../../src/constants';
 
 const { width: SCREEN_WIDTH } = Dimensions.get('window');
 
@@ -52,7 +55,7 @@ const TabLayout = observer(() => {
   const { shouldDisableScroll } = useRadialMenu();
 
   // Register settings handler and sync view with drawer context
-  const { registerSettingsHandler, registerAdminHandler, registerTagManagerHandler, registerCreateSpaceHandler, registerEditSpaceHandler, registerReorderSpacesHandler, setCurrentView: setDrawerView } = useDrawer();
+  const { registerSettingsHandler, registerAdminHandler, registerTagManagerHandler, registerCreateSpaceHandler, registerEditSpaceHandler, registerReorderSpacesHandler, registerNavigateToSpaceHandler, registerNavigateToEverythingHandler, setCurrentView: setDrawerView } = useDrawer();
   // Register create space handler
   const handleCreateSpacePress = useCallback(() => {
     console.log('➕ [TabLayout] handleCreateSpacePress called');
@@ -91,6 +94,35 @@ const TabLayout = observer(() => {
     registerReorderSpacesHandler(handleReorderSpacesPress);
   }, [registerReorderSpacesHandler, handleReorderSpacesPress]);
 
+  // Register navigate to space handler (uses filter system)
+  const handleNavigateToSpace = useCallback((spaceId: string) => {
+    console.log('🧭 [TabLayout] handleNavigateToSpace called for space:', spaceId);
+    // Check if it's the Archive space
+    if (spaceId === SPECIAL_SPACES.ARCHIVE_ID) {
+      filterActions.setShowArchived(true);
+    } else {
+      filterActions.setSelectedSpace(spaceId);
+    }
+    // Make sure we're on the Everything tab
+    setCurrentView('everything');
+  }, []);
+
+  useEffect(() => {
+    registerNavigateToSpaceHandler(handleNavigateToSpace);
+  }, [registerNavigateToSpaceHandler, handleNavigateToSpace]);
+
+  // Register navigate to Everything handler (clears space filter)
+  const handleNavigateToEverything = useCallback(() => {
+    console.log('🧭 [TabLayout] handleNavigateToEverything called');
+    filterActions.clearSelectedSpace();
+    filterActions.setShowArchived(false);
+    setCurrentView('everything');
+  }, []);
+
+  useEffect(() => {
+    registerNavigateToEverythingHandler(handleNavigateToEverything);
+  }, [registerNavigateToEverythingHandler, handleNavigateToEverything]);
+
   // Sync currentView with drawer context for dynamic swipeEdgeWidth
   useEffect(() => {
     setDrawerView(currentView);
@@ -109,6 +141,7 @@ const TabLayout = observer(() => {
   const editSpaceSheetRef = useRef<EditSpaceSheetRef>(null);
   const reorderSpacesSheetRef = useRef<ReorderSpacesSheetRef>(null);
   const chatSheetRef = useRef<BottomSheet>(null);
+  const attachmentSheetRef = useRef<BottomSheet>(null);
   const expandedItemSheetRef = useRef<BottomSheet>(null);
 
   // Dismiss keyboard on mount
@@ -292,6 +325,11 @@ const TabLayout = observer(() => {
     }
   };
 
+  const handleAttachPress = () => {
+    console.log('📎 [TabLayout] handleAttachPress called');
+    attachmentSheetRef.current?.snapToIndex(0);
+  };
+
   const handleViewChange = (view: 'everything' | 'spaces') => {
     console.log('🏠🏠🏠 handleViewChange called - setting currentView to:');
     // Close any open sheets when switching views
@@ -413,6 +451,7 @@ const TabLayout = observer(() => {
         currentView={currentView}
         onViewChange={handleViewChange}
         onAddPress={handleAddPress}
+        onAttachPress={handleAttachPress}
         visible={!isExpandedItemOpen}
       />
 
@@ -555,6 +594,18 @@ const TabLayout = observer(() => {
         />
         <ReorderSpacesSheet
           ref={reorderSpacesSheetRef}
+        />
+        <AttachmentSheet
+          ref={attachmentSheetRef}
+          onPhotoSelected={(uri) => {
+            console.log('📎 [TabLayout] Photo selected:', uri);
+            // TODO: Handle photo attachment in chat
+            showToast({
+              message: 'Photo selected! Integration coming soon.',
+              type: 'success',
+              duration: 2000,
+            });
+          }}
         />
       </View>
 

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -155,7 +155,10 @@ const TabLayout = observer(() => {
     if (pathname.includes('/spaces') && currentView !== 'spaces') {
       console.log('✅ Switching to spaces view');
       setCurrentView('spaces');
-    } else if (pathname === '/(tabs)' || pathname === '/' && currentView !== 'everything') {
+    } else if (pathname.includes('/assistant') && currentView !== 'spaces') {
+      console.log('✅ Switching to chat/assistant view');
+      setCurrentView('spaces'); // Chat tab uses 'spaces' view state
+    } else if ((pathname === '/(tabs)' || pathname === '/') && currentView !== 'everything') {
       console.log('✅ Switching to everything view');
       setCurrentView('everything');
     }
@@ -595,23 +598,23 @@ const TabLayout = observer(() => {
         <ReorderSpacesSheet
           ref={reorderSpacesSheetRef}
         />
-        <AttachmentSheet
-          ref={attachmentSheetRef}
-          onPhotoSelected={(uri) => {
-            console.log('📎 [TabLayout] Photo selected:', uri);
-            // TODO: Handle photo attachment in chat
-            showToast({
-              message: 'Photo selected! Integration coming soon.',
-              type: 'success',
-              duration: 2000,
-            });
-          }}
-        />
       </View>
 
-        {/* Chat Sheet Modal - absolute container with higher z-index so it sits above everything */}
+        {/* Chat-related sheets - higher z-index so they appear above everything */}
         <View style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0, zIndex: 1000, pointerEvents: 'box-none' }}>
           <ChatSheet ref={chatSheetRef} />
+          <AttachmentSheet
+            ref={attachmentSheetRef}
+            onPhotoSelected={(uri) => {
+              console.log('📎 [TabLayout] Photo selected:', uri);
+              // TODO: Handle photo attachment in chat
+              showToast({
+                message: 'Photo selected! Integration coming soon.',
+                type: 'success',
+                duration: 2000,
+              });
+            }}
+          />
         </View>
       </View>
     </BottomSheetModalProvider>

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -89,7 +89,7 @@ const RootLayoutContent = observer(() => {
       drawerType="slide"
       drawerStyle={{
         backgroundColor: isDarkMode ? '#000000' : '#FFFFFF',
-        width: SCREEN_WIDTH,
+        width: SCREEN_WIDTH * 0.9,
       }}
       overlayStyle={{
         backgroundColor: isDarkMode ? 'rgba(0, 0, 0, 0.7)' : 'rgba(0, 0, 0, 0.5)',

--- a/src/components/AssistantChat.tsx
+++ b/src/components/AssistantChat.tsx
@@ -496,8 +496,8 @@ const AssistantChat = observer(() => {
             // When keyboard hidden: add 80px for bottom nav clearance
             // When keyboard shown: just use safe area (keyboard covers nav)
             paddingBottom: keyboardVisible
-              ? Math.max(insets.bottom, 10)
-              : Math.max(insets.bottom, 10) + 80,
+              ? Math.max(insets.bottom, 10) - 20
+              : Math.max(insets.bottom, 10) + 65,
           },
         ]}
       >

--- a/src/components/AssistantChat.tsx
+++ b/src/components/AssistantChat.tsx
@@ -14,6 +14,7 @@ import {
   Keyboard,
 } from 'react-native';
 import { MaterialIcons } from '@expo/vector-icons';
+import { Host, ContextMenu, Button } from '@expo/ui/swift-ui';
 import { observer } from '@legendapp/state/react';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import * as Clipboard from 'expo-clipboard';
@@ -307,6 +308,37 @@ const AssistantChat = observer(() => {
     );
   };
 
+  const handleRenameChat = () => {
+    const currentConversation = assistantComputed.currentConversation();
+    if (!currentConversation) return;
+
+    const currentTitle = currentConversation.title || 'New Chat';
+
+    Alert.prompt(
+      'Rename Chat',
+      'Enter a new name for this chat:',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Rename',
+          onPress: (newTitle: string | undefined) => {
+            if (newTitle && newTitle.trim()) {
+              assistantActions.updateTitle(currentConversation.id, newTitle.trim());
+              Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+              showToast({
+                message: 'Chat renamed',
+                type: 'success',
+                duration: 2000,
+              });
+            }
+          },
+        },
+      ],
+      'plain-text',
+      currentTitle
+    );
+  };
+
   const handleCopyMessage = async (content: string) => {
     try {
       await Clipboard.setStringAsync(content);
@@ -403,17 +435,32 @@ const AssistantChat = observer(() => {
                 color={isDarkMode ? '#FFFFFF' : '#000000'}
               />
             </TouchableOpacity>
-            <TouchableOpacity
-              style={styles.headerButton}
-              onPress={handleClearChat}
-              hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
-            >
-              <MaterialIcons
-                name="delete-outline"
-                size={24}
-                color={isDarkMode ? '#FFFFFF' : '#000000'}
-              />
-            </TouchableOpacity>
+            <Host>
+              <ContextMenu>
+                <ContextMenu.Trigger>
+                  <TouchableOpacity
+                    style={styles.headerButton}
+                    onPress={() => {
+                      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+                    }}
+                  >
+                    <MaterialIcons
+                      name="more-vert"
+                      size={24}
+                      color={isDarkMode ? '#FFFFFF' : '#000000'}
+                    />
+                  </TouchableOpacity>
+                </ContextMenu.Trigger>
+                <ContextMenu.Items>
+                  <Button onPress={handleRenameChat}>
+                    Rename Chat
+                  </Button>
+                  <Button onPress={handleClearChat} role="destructive">
+                    Clear Chat
+                  </Button>
+                </ContextMenu.Items>
+              </ContextMenu>
+            </Host>
           </View>
         </View>
       </View>

--- a/src/components/AssistantChat.tsx
+++ b/src/components/AssistantChat.tsx
@@ -475,6 +475,7 @@ const AssistantChat = observer(() => {
         ]}
         showsVerticalScrollIndicator={false}
         keyboardShouldPersistTaps="handled"
+        keyboardDismissMode="on-drag"
       >
         {messages.length === 0 ? (
           renderWelcome()

--- a/src/components/AttachmentSheet.tsx
+++ b/src/components/AttachmentSheet.tsx
@@ -1,0 +1,380 @@
+import React, { forwardRef, useMemo, useCallback } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  Alert,
+} from 'react-native';
+import BottomSheet, { BottomSheetBackdrop } from '@gorhom/bottom-sheet';
+import { MaterialIcons } from '@expo/vector-icons';
+import { observer } from '@legendapp/state/react';
+import * as ImagePicker from 'expo-image-picker';
+import { themeStore } from '../stores/theme';
+import { COLORS } from '../constants';
+import { useToast } from '../contexts/ToastContext';
+
+interface AttachmentSheetProps {
+  onOpen?: () => void;
+  onClose?: () => void;
+  onPhotoSelected?: (uri: string) => void;
+  onFileSelected?: (uri: string) => void;
+  onLinkAttach?: () => void;
+  onItemsAttach?: () => void;
+}
+
+export interface AttachmentSheetRef {
+  open: () => void;
+  close: () => void;
+}
+
+const AttachmentSheet = observer(
+  forwardRef<BottomSheet, AttachmentSheetProps>(
+    ({ onOpen, onClose, onPhotoSelected, onFileSelected, onLinkAttach, onItemsAttach }, ref) => {
+      const isDarkMode = themeStore.isDarkMode.get();
+      const { showToast } = useToast();
+
+      // Snap points for the bottom sheet
+      const snapPoints = useMemo(() => ['40%'], []);
+
+      // Render backdrop
+      const renderBackdrop = useCallback(
+        (props: any) => (
+          <BottomSheetBackdrop
+            {...props}
+            disappearsOnIndex={-1}
+            appearsOnIndex={0}
+            opacity={0.5}
+          />
+        ),
+        []
+      );
+
+      const handlePickPhoto = async () => {
+        try {
+          const { status } = await ImagePicker.requestMediaLibraryPermissionsAsync();
+          if (status !== 'granted') {
+            Alert.alert('Permission needed', 'Please grant photo library access to attach photos.');
+            return;
+          }
+
+          const result = await ImagePicker.launchImageLibraryAsync({
+            mediaTypes: ImagePicker.MediaTypeOptions.Images,
+            allowsEditing: false,
+            quality: 0.8,
+          });
+
+          if (!result.canceled && result.assets[0]) {
+            onPhotoSelected?.(result.assets[0].uri);
+            (ref as any)?.current?.close();
+          }
+        } catch (error) {
+          console.error('Error picking photo:', error);
+          showToast({
+            message: 'Failed to pick photo',
+            type: 'error',
+            duration: 2000,
+          });
+        }
+      };
+
+      const handleTakePhoto = async () => {
+        try {
+          const { status } = await ImagePicker.requestCameraPermissionsAsync();
+          if (status !== 'granted') {
+            Alert.alert('Permission needed', 'Please grant camera access to take photos.');
+            return;
+          }
+
+          const result = await ImagePicker.launchCameraAsync({
+            allowsEditing: false,
+            quality: 0.8,
+          });
+
+          if (!result.canceled && result.assets[0]) {
+            onPhotoSelected?.(result.assets[0].uri);
+            (ref as any)?.current?.close();
+          }
+        } catch (error) {
+          console.error('Error taking photo:', error);
+          showToast({
+            message: 'Failed to take photo',
+            type: 'error',
+            duration: 2000,
+          });
+        }
+      };
+
+      const handleAttachFile = () => {
+        // TODO: Implement file picker using expo-document-picker
+        showToast({
+          message: 'File attachment coming soon!',
+          type: 'info',
+          duration: 2000,
+        });
+      };
+
+      const handleAttachLink = () => {
+        if (onLinkAttach) {
+          onLinkAttach();
+        } else {
+          // TODO: Show link input dialog
+          showToast({
+            message: 'Link attachment coming soon!',
+            type: 'info',
+            duration: 2000,
+          });
+        }
+        (ref as any)?.current?.close();
+      };
+
+      const handleAttachItems = () => {
+        if (onItemsAttach) {
+          onItemsAttach();
+        } else {
+          showToast({
+            message: 'Attach from Memex coming soon!',
+            type: 'info',
+            duration: 2000,
+          });
+        }
+        (ref as any)?.current?.close();
+      };
+
+      return (
+        <BottomSheet
+          ref={ref}
+          index={-1}
+          snapPoints={snapPoints}
+          enablePanDownToClose
+          backdropComponent={renderBackdrop}
+          topInset={50}
+          backgroundStyle={[
+            styles.sheetBackground,
+            isDarkMode && styles.sheetBackgroundDark,
+          ]}
+          handleIndicatorStyle={[
+            styles.handleIndicator,
+            isDarkMode && styles.handleIndicatorDark,
+          ]}
+          onChange={(index) => {
+            if (index === -1) {
+              onClose?.();
+            } else if (index >= 0) {
+              onOpen?.();
+            }
+          }}
+        >
+          <View style={styles.header}>
+            <Text style={[styles.title, isDarkMode && styles.titleDark]}>
+              Attach
+            </Text>
+          </View>
+
+          <View style={styles.content}>
+            {/* Photo Options */}
+            <TouchableOpacity
+              style={[styles.optionRow, isDarkMode && styles.optionRowDark]}
+              onPress={handlePickPhoto}
+              activeOpacity={0.7}
+            >
+              <View style={[styles.iconContainer, { backgroundColor: COLORS.primary }]}>
+                <MaterialIcons name="photo-library" size={24} color="#FFFFFF" />
+              </View>
+              <View style={styles.optionContent}>
+                <Text style={[styles.optionTitle, isDarkMode && styles.optionTitleDark]}>
+                  Choose Photo
+                </Text>
+                <Text style={[styles.optionSubtitle, isDarkMode && styles.optionSubtitleDark]}>
+                  Select from your photo library
+                </Text>
+              </View>
+              <MaterialIcons
+                name="chevron-right"
+                size={24}
+                color={isDarkMode ? '#666666' : '#CCCCCC'}
+              />
+            </TouchableOpacity>
+
+            <TouchableOpacity
+              style={[styles.optionRow, isDarkMode && styles.optionRowDark]}
+              onPress={handleTakePhoto}
+              activeOpacity={0.7}
+            >
+              <View style={[styles.iconContainer, { backgroundColor: COLORS.success }]}>
+                <MaterialIcons name="camera-alt" size={24} color="#FFFFFF" />
+              </View>
+              <View style={styles.optionContent}>
+                <Text style={[styles.optionTitle, isDarkMode && styles.optionTitleDark]}>
+                  Take Photo
+                </Text>
+                <Text style={[styles.optionSubtitle, isDarkMode && styles.optionSubtitleDark]}>
+                  Use your camera
+                </Text>
+              </View>
+              <MaterialIcons
+                name="chevron-right"
+                size={24}
+                color={isDarkMode ? '#666666' : '#CCCCCC'}
+              />
+            </TouchableOpacity>
+
+            {/* File Option */}
+            <TouchableOpacity
+              style={[styles.optionRow, isDarkMode && styles.optionRowDark]}
+              onPress={handleAttachFile}
+              activeOpacity={0.7}
+            >
+              <View style={[styles.iconContainer, { backgroundColor: COLORS.warning }]}>
+                <MaterialIcons name="attach-file" size={24} color="#FFFFFF" />
+              </View>
+              <View style={styles.optionContent}>
+                <Text style={[styles.optionTitle, isDarkMode && styles.optionTitleDark]}>
+                  Attach File
+                </Text>
+                <Text style={[styles.optionSubtitle, isDarkMode && styles.optionSubtitleDark]}>
+                  Documents, PDFs, and more
+                </Text>
+              </View>
+              <MaterialIcons
+                name="chevron-right"
+                size={24}
+                color={isDarkMode ? '#666666' : '#CCCCCC'}
+              />
+            </TouchableOpacity>
+
+            {/* Link Option */}
+            <TouchableOpacity
+              style={[styles.optionRow, isDarkMode && styles.optionRowDark]}
+              onPress={handleAttachLink}
+              activeOpacity={0.7}
+            >
+              <View style={[styles.iconContainer, { backgroundColor: '#9B59B6' }]}>
+                <MaterialIcons name="link" size={24} color="#FFFFFF" />
+              </View>
+              <View style={styles.optionContent}>
+                <Text style={[styles.optionTitle, isDarkMode && styles.optionTitleDark]}>
+                  Attach Link
+                </Text>
+                <Text style={[styles.optionSubtitle, isDarkMode && styles.optionSubtitleDark]}>
+                  Share a URL
+                </Text>
+              </View>
+              <MaterialIcons
+                name="chevron-right"
+                size={24}
+                color={isDarkMode ? '#666666' : '#CCCCCC'}
+              />
+            </TouchableOpacity>
+
+            {/* Items from Memex Option */}
+            <TouchableOpacity
+              style={[styles.optionRow, styles.lastOptionRow, isDarkMode && styles.optionRowDark]}
+              onPress={handleAttachItems}
+              activeOpacity={0.7}
+            >
+              <View style={[styles.iconContainer, { backgroundColor: '#3498DB' }]}>
+                <MaterialIcons name="inventory-2" size={24} color="#FFFFFF" />
+              </View>
+              <View style={styles.optionContent}>
+                <Text style={[styles.optionTitle, isDarkMode && styles.optionTitleDark]}>
+                  From Memex
+                </Text>
+                <Text style={[styles.optionSubtitle, isDarkMode && styles.optionSubtitleDark]}>
+                  Reference your saved items
+                </Text>
+              </View>
+              <MaterialIcons
+                name="chevron-right"
+                size={24}
+                color={isDarkMode ? '#666666' : '#CCCCCC'}
+              />
+            </TouchableOpacity>
+          </View>
+        </BottomSheet>
+      );
+    }
+  )
+);
+
+const styles = StyleSheet.create({
+  sheetBackground: {
+    backgroundColor: '#FFFFFF',
+    borderTopLeftRadius: 20,
+    borderTopRightRadius: 20,
+  },
+  sheetBackgroundDark: {
+    backgroundColor: '#1C1C1E',
+  },
+  handleIndicator: {
+    backgroundColor: '#DDDDDD',
+    width: 36,
+    height: 4,
+  },
+  handleIndicatorDark: {
+    backgroundColor: '#555555',
+  },
+  header: {
+    paddingHorizontal: 20,
+    paddingTop: 8,
+    paddingBottom: 16,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: '#E5E5E7',
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: '600',
+    color: '#000000',
+    textAlign: 'center',
+  },
+  titleDark: {
+    color: '#FFFFFF',
+  },
+  content: {
+    paddingHorizontal: 16,
+    paddingTop: 12,
+  },
+  optionRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 12,
+    paddingHorizontal: 4,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: '#E5E5E7',
+  },
+  optionRowDark: {
+    borderBottomColor: '#38383A',
+  },
+  lastOptionRow: {
+    borderBottomWidth: 0,
+  },
+  iconContainer: {
+    width: 44,
+    height: 44,
+    borderRadius: 10,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginRight: 14,
+  },
+  optionContent: {
+    flex: 1,
+  },
+  optionTitle: {
+    fontSize: 16,
+    fontWeight: '500',
+    color: '#000000',
+    marginBottom: 2,
+  },
+  optionTitleDark: {
+    color: '#FFFFFF',
+  },
+  optionSubtitle: {
+    fontSize: 13,
+    color: '#666666',
+  },
+  optionSubtitleDark: {
+    color: '#999999',
+  },
+});
+
+export default AttachmentSheet;

--- a/src/components/BottomNavigation.tsx
+++ b/src/components/BottomNavigation.tsx
@@ -8,12 +8,13 @@ import { Host, ZStack, Image } from '@expo/ui/swift-ui';
 import { frame, glassEffect, onTapGesture } from '@expo/ui/swift-ui/modifiers';
 import { themeStore } from '../stores/theme';
 import { COLORS } from '../constants';
-import { FilterContextMenuTrigger } from './FilterContextMenuTrigger';
+import { useDrawer } from '../contexts/DrawerContext';
 
 interface BottomNavigationProps {
   currentView: 'everything' | 'spaces';
   onViewChange: (view: 'everything' | 'spaces') => void;
   onAddPress: () => void;
+  onAttachPress?: () => void;
   visible?: boolean;
 }
 
@@ -21,10 +22,12 @@ const BottomNavigation = observer(({
   currentView,
   onViewChange,
   onAddPress,
+  onAttachPress,
   visible = true,
 }: BottomNavigationProps) => {
   const isDarkMode = themeStore.isDarkMode.get();
   const insets = useSafeAreaInsets();
+  const { openDrawer } = useDrawer();
 
   // if (!visible) return null;
 
@@ -41,20 +44,21 @@ const BottomNavigation = observer(({
           { bottom: insets.bottom - 20 },
         ]}
       >
-        <FilterContextMenuTrigger hostStyle={{ width: 60, height: 60 }}>
+        <Host style={{ width: 60, height: 60 }}>
           <ZStack
             modifiers={[
               frame({ width: 60, height: 60 }),
-              glassEffect({ glass: { variant: 'regular', interactive: true }, shape: 'circle' })
+              glassEffect({ glass: { variant: 'regular', interactive: true }, shape: 'circle' }),
+              onTapGesture(openDrawer)
             ]}
           >
             <Image
-              systemName="line.3.horizontal.decrease"
+              systemName="line.3.horizontal"
               size={24}
               color={iconColor}
             />
           </ZStack>
-        </FilterContextMenuTrigger>
+        </Host>
       </View>
 
       {/* Native Tabs with Liquid Glass Effect */}
@@ -106,7 +110,8 @@ const BottomNavigation = observer(({
         </NativeTabs.Trigger>
       </NativeTabs>
 
-      {/* Add Item Button - Bottom Right */}
+      {/* Context-Specific Action Button - Bottom Right */}
+      {/* Everything tab: Add item (+), Chat tab: Attach (paperclip) */}
       <View
         style={[
           styles.glassButtonHost,
@@ -119,11 +124,11 @@ const BottomNavigation = observer(({
             modifiers={[
               frame({ width: 60, height: 60 }),
               glassEffect({ glass: { variant: 'regular', interactive: true }, shape: 'circle' }),
-              onTapGesture(onAddPress)
+              onTapGesture(currentView === 'everything' ? onAddPress : (onAttachPress || (() => {})))
             ]}
           >
             <Image
-              systemName="plus"
+              systemName={currentView === 'everything' ? 'plus' : 'paperclip'}
               size={24}
               color={iconColor}
             />

--- a/src/components/BottomNavigation.tsx
+++ b/src/components/BottomNavigation.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef } from 'react';
 import { View, StyleSheet } from 'react-native';
 import { MaterialIcons, Ionicons } from '@expo/vector-icons';
 import { observer } from '@legendapp/state/react';
@@ -28,6 +28,27 @@ const BottomNavigation = observer(({
   const isDarkMode = themeStore.isDarkMode.get();
   const insets = useSafeAreaInsets();
   const { openDrawer } = useDrawer();
+
+  // Use refs to ensure callbacks always have current values
+  // SwiftUI's onTapGesture may cache the callback
+  const currentViewRef = useRef(currentView);
+  const onAddPressRef = useRef(onAddPress);
+  const onAttachPressRef = useRef(onAttachPress);
+
+  // Keep refs updated
+  currentViewRef.current = currentView;
+  onAddPressRef.current = onAddPress;
+  onAttachPressRef.current = onAttachPress;
+
+  // Stable callback that reads from refs
+  const handleRightButtonPress = useCallback(() => {
+    console.log('📎 [BottomNav] Right button pressed, currentView:', currentViewRef.current);
+    if (currentViewRef.current === 'everything') {
+      onAddPressRef.current();
+    } else {
+      onAttachPressRef.current?.();
+    }
+  }, []);
 
   // if (!visible) return null;
 
@@ -124,7 +145,7 @@ const BottomNavigation = observer(({
             modifiers={[
               frame({ width: 60, height: 60 }),
               glassEffect({ glass: { variant: 'regular', interactive: true }, shape: 'circle' }),
-              onTapGesture(currentView === 'everything' ? onAddPress : (onAttachPress || (() => {})))
+              onTapGesture(handleRightButtonPress)
             ]}
           >
             <Image

--- a/src/components/FilterPills.tsx
+++ b/src/components/FilterPills.tsx
@@ -4,28 +4,41 @@ import { observer } from '@legendapp/state/react';
 import { Ionicons } from '@expo/vector-icons';
 import { themeStore } from '../stores/theme';
 import { filterStore, filterActions } from '../stores/filter';
+import { spacesComputed } from '../stores/spaces';
 import { ContentType } from '../types';
 
-// Map content types to display names
-const CONTENT_TYPE_LABELS: Record<ContentType, string> = {
+// Map content types to display names (partial - only commonly filtered types)
+const CONTENT_TYPE_LABELS: Partial<Record<ContentType, string>> = {
   bookmark: 'Bookmark',
   youtube: 'YouTube',
+  youtube_short: 'YouTube Short',
   x: 'X/Twitter',
   instagram: 'Instagram',
   reddit: 'Reddit',
   note: 'Note',
   movie: 'Movie',
-  tv: 'TV Show',
+  tv_show: 'TV Show',
   product: 'Product',
+  podcast: 'Podcast',
+  article: 'Article',
+  book: 'Book',
+  image: 'Image',
+  video: 'Video',
 };
 
 const FilterPills = observer(() => {
   const isDarkMode = themeStore.isDarkMode.get();
   const selectedContentType = filterStore.selectedContentType.get();
   const selectedTags = filterStore.selectedTags.get();
+  const selectedSpaceId = filterStore.selectedSpaceId.get();
+  const showArchived = filterStore.showArchived.get();
+  const spaces = spacesComputed.activeSpaces();
+
+  // Get selected space name
+  const selectedSpace = selectedSpaceId ? spaces.find(s => s.id === selectedSpaceId) : null;
 
   // Don't render anything if no filters are active
-  if (!selectedContentType && selectedTags.length === 0) {
+  if (!selectedContentType && selectedTags.length === 0 && !selectedSpaceId && !showArchived) {
     return null;
   }
 
@@ -37,6 +50,14 @@ const FilterPills = observer(() => {
     filterActions.toggleTag(tag);
   };
 
+  const handleRemoveSpace = () => {
+    filterActions.clearSelectedSpace();
+  };
+
+  const handleRemoveArchive = () => {
+    filterActions.setShowArchived(false);
+  };
+
   return (
     <View style={[styles.container, isDarkMode && styles.containerDark]}>
       <ScrollView
@@ -44,6 +65,53 @@ const FilterPills = observer(() => {
         showsHorizontalScrollIndicator={false}
         contentContainerStyle={styles.scrollContent}
       >
+        {/* Space filter pill */}
+        {selectedSpace && (
+          <View style={[styles.pill, styles.spacePill, isDarkMode && styles.pillDark]}>
+            <Text style={[styles.pillText, isDarkMode && styles.pillTextDark]}>
+              Space: {selectedSpace.name}
+            </Text>
+            <TouchableOpacity
+              onPress={handleRemoveSpace}
+              style={styles.removeButton}
+              hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+            >
+              <Ionicons
+                name="close-circle"
+                size={16}
+                color={isDarkMode ? '#8E8E93' : '#666'}
+              />
+            </TouchableOpacity>
+          </View>
+        )}
+
+        {/* Archive filter pill */}
+        {showArchived && (
+          <View style={[styles.pill, styles.archivePill, isDarkMode && styles.pillDark]}>
+            <Ionicons
+              name="archive-outline"
+              size={14}
+              color={isDarkMode ? '#F2F2F7' : '#333'}
+              style={{ marginRight: 4 }}
+            />
+            <Text style={[styles.pillText, isDarkMode && styles.pillTextDark]}>
+              Archive
+            </Text>
+            <TouchableOpacity
+              onPress={handleRemoveArchive}
+              style={styles.removeButton}
+              hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+            >
+              <Ionicons
+                name="close-circle"
+                size={16}
+                color={isDarkMode ? '#8E8E93' : '#666'}
+              />
+            </TouchableOpacity>
+          </View>
+        )}
+
+        {/* Content type filter pill */}
         {selectedContentType && (
           <View style={[styles.pill, isDarkMode && styles.pillDark]}>
             <Text style={[styles.pillText, isDarkMode && styles.pillTextDark]}>
@@ -63,6 +131,7 @@ const FilterPills = observer(() => {
           </View>
         )}
 
+        {/* Tag filter pills */}
         {selectedTags.map((tag) => (
           <View key={tag} style={[styles.pill, styles.tagPill, isDarkMode && styles.pillDark]}>
             <Text style={[styles.pillText, isDarkMode && styles.pillTextDark]}>
@@ -120,6 +189,12 @@ const styles = StyleSheet.create({
   },
   tagPill: {
     // Could add different styling for tags if needed
+  },
+  spacePill: {
+    backgroundColor: '#007AFF20',
+  },
+  archivePill: {
+    backgroundColor: '#FF950020',
   },
   pillText: {
     fontSize: 14,

--- a/src/components/SimpleHeader.tsx
+++ b/src/components/SimpleHeader.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { observer } from '@legendapp/state/react';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { MaterialIcons } from '@expo/vector-icons';
+import { Host } from '@expo/ui/swift-ui';
+import { themeStore } from '../stores/theme';
+import { filterStore } from '../stores/filter';
+import { spacesComputed } from '../stores/spaces';
+import { FilterContextMenuTrigger } from './FilterContextMenuTrigger';
+
+interface SimpleHeaderProps {
+  onFilterPress?: () => void;
+}
+
+const SimpleHeader = observer(({ onFilterPress }: SimpleHeaderProps) => {
+  const insets = useSafeAreaInsets();
+  const isDarkMode = themeStore.isDarkMode.get();
+
+  // Determine the title based on current filter state
+  const selectedSpaceId = filterStore.selectedSpaceId?.get?.() || null;
+  const showArchived = filterStore.showArchived?.get?.() || false;
+
+  let title = 'Everything';
+
+  if (showArchived) {
+    title = 'Archive';
+  } else if (selectedSpaceId) {
+    const spaces = spacesComputed.activeSpaces();
+    const selectedSpace = spaces.find(s => s.id === selectedSpaceId);
+    if (selectedSpace) {
+      title = selectedSpace.name;
+    }
+  }
+
+  const textColor = isDarkMode ? '#FFFFFF' : '#000000';
+
+  return (
+    <View style={[styles.container, { paddingTop: insets.top }, isDarkMode && styles.containerDark]}>
+      <View style={styles.content}>
+        <Text style={[styles.title, { color: textColor }]}>{title}</Text>
+
+        <FilterContextMenuTrigger>
+          <TouchableOpacity
+            style={styles.filterButton}
+            activeOpacity={0.7}
+            onPress={onFilterPress}
+          >
+            <MaterialIcons
+              name="filter-list"
+              size={26}
+              color={textColor}
+            />
+          </TouchableOpacity>
+        </FilterContextMenuTrigger>
+      </View>
+    </View>
+  );
+});
+
+export default SimpleHeader;
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: 'rgba(255,255,255,0.95)',
+    paddingBottom: 12,
+  },
+  containerDark: {
+    backgroundColor: 'rgba(0,0,0,0.95)',
+  },
+  content: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 20,
+  },
+  title: {
+    fontSize: 28,
+    fontWeight: 'bold',
+  },
+  filterButton: {
+    padding: 8,
+    borderRadius: 8,
+  },
+});


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds space/archive filtering with a simplified single-list home and header, integrates an attachment sheet and chat actions, and updates bottom nav/drawer behavior.
> 
> - **Navigation/UI**
>   - `BottomNavigation`: left glass button now opens the drawer; right action is context-aware (`+` on `everything`, `paperclip` on chat).
>   - `app/_layout.tsx`: drawer width set to `SCREEN_WIDTH * 0.9` and edge swipe tuning remains.
>   - `app/(tabs)/_layout.tsx`: wires `onAttachPress`, registers navigate-to-space/everything handlers using the filter system, and routes assistant as the second view.
> - **Filtering & Home**
>   - `src/stores/filter.ts`: adds `selectedSpaceId` and `showArchived` with actions, persistence, and `hasActiveFilters` update.
>   - `src/components/FilterContextMenuTrigger.tsx`: new Space submenu (All, per-space, Archive, Manage Spaces...).
>   - `src/components/FilterPills.tsx`: shows pills for Space, Archive, Type, and Tags.
>   - `app/(tabs)/index.tsx`: removes pager/spaces pages; uses a single `FlashList` driven by filters; adds `SimpleHeader` and enhanced empty states.
>   - `src/components/SimpleHeader.tsx`: new header reflecting current space/archive and exposing filter menu.
> - **Chat**
>   - `src/components/AttachmentSheet.tsx`: new bottom sheet (choose/take photo, file, link, from Memex); integrated in `app/(tabs)/_layout.tsx` and triggered from bottom-right action on chat.
>   - `src/components/AssistantChat.tsx`: adds context menu (Rename Chat, Clear Chat), enables `keyboardDismissMode="on-drag"`, and refines input padding.
> - **Misc**
>   - `app.json` iOS `buildNumber` bumped to `2025.12.03.2`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 67ca6578e21e66a1d6b528841edea2486a29b7f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->